### PR TITLE
Add client and admin route groups with Livewire placeholders

### DIFF
--- a/app/Livewire/AdminDashboardLivewireComponent.php
+++ b/app/Livewire/AdminDashboardLivewireComponent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class AdminDashboardLivewireComponent extends Component
+{
+    public function render()
+    {
+        return view('admin.dashboard');
+    }
+}

--- a/app/Livewire/AdminOrdersLivewireComponent.php
+++ b/app/Livewire/AdminOrdersLivewireComponent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class AdminOrdersLivewireComponent extends Component
+{
+    public function render()
+    {
+        return view('admin.orders');
+    }
+}

--- a/app/Livewire/ClientDashboardLivewireComponent.php
+++ b/app/Livewire/ClientDashboardLivewireComponent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class ClientDashboardLivewireComponent extends Component
+{
+    public function render()
+    {
+        return view('client.dashboard');
+    }
+}

--- a/app/Livewire/ClientOrdersLivewireComponent.php
+++ b/app/Livewire/ClientOrdersLivewireComponent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class ClientOrdersLivewireComponent extends Component
+{
+    public function render()
+    {
+        return view('client.orders');
+    }
+}

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,7 +1,1 @@
-<!DOCTYPE html>
-<html>
-<head><title>Admin Dashboard</title></head>
-<body>
-<h1>Admin Dashboard</h1>
-</body>
-</html>
+<div>Admin Dashboard Placeholder</div>

--- a/resources/views/admin/orders.blade.php
+++ b/resources/views/admin/orders.blade.php
@@ -1,0 +1,1 @@
+<div>Admin Orders Placeholder</div>

--- a/resources/views/client/dashboard.blade.php
+++ b/resources/views/client/dashboard.blade.php
@@ -1,7 +1,1 @@
-<!DOCTYPE html>
-<html>
-<head><title>Client Dashboard</title></head>
-<body>
-<h1>Client Dashboard</h1>
-</body>
-</html>
+<div>Client Dashboard Placeholder</div>

--- a/resources/views/client/orders.blade.php
+++ b/resources/views/client/orders.blade.php
@@ -1,0 +1,1 @@
+<div>Client Orders Placeholder</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,10 @@
 <?php
 
 use App\Http\Controllers\AuthController;
+use App\Livewire\AdminDashboardLivewireComponent;
+use App\Livewire\AdminOrdersLivewireComponent;
+use App\Livewire\ClientDashboardLivewireComponent;
+use App\Livewire\ClientOrdersLivewireComponent;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -10,10 +14,12 @@ Route::get('/', function () {
 Route::get('/login', [AuthController::class, 'showLoginForm'])->name('login');
 Route::post('/login', [AuthController::class, 'login'])->name('login.post');
 
-Route::middleware(['auth', 'role:admin', 'can:viewAdminDashboard'])->get('/admin/dashboard', function () {
-    return view('admin.dashboard');
-})->name('admin.dashboard');
+Route::middleware(['auth', 'role:client'])->prefix('client')->name('client.')->group(function () {
+    Route::get('dashboard', ClientDashboardLivewireComponent::class)->name('dashboard');
+    Route::get('orders', ClientOrdersLivewireComponent::class)->name('orders');
+});
 
-Route::middleware(['auth', 'role:client', 'can:viewClientDashboard'])->get('/client/dashboard', function () {
-    return view('client.dashboard');
-})->name('client.dashboard');
+Route::middleware(['auth', 'role:admin'])->prefix('admin')->name('admin.')->group(function () {
+    Route::get('dashboard', AdminDashboardLivewireComponent::class)->name('dashboard');
+    Route::get('orders', AdminOrdersLivewireComponent::class)->name('orders');
+});


### PR DESCRIPTION
## Summary
- group client routes with auth role and Livewire dashboard/orders components
- group admin routes with auth role and Livewire dashboard/orders components
- scaffold placeholder views for client and admin dashboards and orders

## Testing
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_689518bbcda48329b5ec1dde7477ffab