### PR TITLE
Add role-based dashboards with metrics and navigation

### DIFF
--- a/app/Livewire/AdminDashboardLivewireComponent.php
+++ b/app/Livewire/AdminDashboardLivewireComponent.php
@@ -2,12 +2,30 @@
 
 namespace App\Livewire;
 
+use App\Models\Location;
+use App\Models\Order;
+use App\Models\Schedule;
+use App\Models\User;
 use Livewire\Component;
 
 class AdminDashboardLivewireComponent extends Component
 {
+    public int $ordersCount;
+    public int $schedulesCount;
+    public int $locationsCount;
+    public int $teamCount;
+
+    public function mount(): void
+    {
+        $this->ordersCount = Order::count();
+        $this->schedulesCount = Schedule::count();
+        $this->locationsCount = Location::count();
+        $this->teamCount = User::count();
+    }
+
     public function render()
     {
         return view('admin.dashboard');
     }
 }
+

--- a/app/Livewire/AdminLocationsLivewireComponent.php
+++ b/app/Livewire/AdminLocationsLivewireComponent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class AdminLocationsLivewireComponent extends Component
+{
+    public function render()
+    {
+        return view('admin.locations');
+    }
+}
+

--- a/app/Livewire/AdminSchedulesLivewireComponent.php
+++ b/app/Livewire/AdminSchedulesLivewireComponent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class AdminSchedulesLivewireComponent extends Component
+{
+    public function render()
+    {
+        return view('admin.schedules');
+    }
+}
+

--- a/app/Livewire/AdminTeamLivewireComponent.php
+++ b/app/Livewire/AdminTeamLivewireComponent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class AdminTeamLivewireComponent extends Component
+{
+    public function render()
+    {
+        return view('admin.team');
+    }
+}
+

--- a/app/Livewire/ClientDashboardLivewireComponent.php
+++ b/app/Livewire/ClientDashboardLivewireComponent.php
@@ -2,12 +2,34 @@
 
 namespace App\Livewire;
 
+use App\Models\Location;
+use App\Models\Order;
+use App\Models\Schedule;
+use App\Models\User;
 use Livewire\Component;
 
 class ClientDashboardLivewireComponent extends Component
 {
+    public int $ordersCount;
+    public int $schedulesCount;
+    public int $locationsCount;
+    public int $teamCount;
+
+    public function mount(): void
+    {
+        $clientIds = auth()->user()->clients()->pluck('clients.id');
+
+        $this->ordersCount = Order::whereIn('client_id', $clientIds)->count();
+        $this->schedulesCount = Schedule::whereIn('client_id', $clientIds)->count();
+        $this->locationsCount = Location::whereIn('client_id', $clientIds)->count();
+        $this->teamCount = User::whereHas('clients', function ($query) use ($clientIds) {
+            $query->whereIn('client_id', $clientIds);
+        })->count();
+    }
+
     public function render()
     {
         return view('client.dashboard');
     }
 }
+

--- a/app/Livewire/ClientLocationsLivewireComponent.php
+++ b/app/Livewire/ClientLocationsLivewireComponent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class ClientLocationsLivewireComponent extends Component
+{
+    public function render()
+    {
+        return view('client.locations');
+    }
+}
+

--- a/app/Livewire/ClientSchedulesLivewireComponent.php
+++ b/app/Livewire/ClientSchedulesLivewireComponent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class ClientSchedulesLivewireComponent extends Component
+{
+    public function render()
+    {
+        return view('client.schedules');
+    }
+}
+

--- a/app/Livewire/ClientTeamLivewireComponent.php
+++ b/app/Livewire/ClientTeamLivewireComponent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class ClientTeamLivewireComponent extends Component
+{
+    public function render()
+    {
+        return view('client.team');
+    }
+}
+

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,1 +1,17 @@
-<div>Admin Dashboard Placeholder</div>
+<div>
+    <h1>Admin Dashboard</h1>
+
+    <nav>
+        <a href="{{ route('admin.orders') }}">Orders</a>
+        <a href="{{ route('admin.schedules') }}">Schedules</a>
+        <a href="{{ route('admin.locations') }}">Locations</a>
+        <a href="{{ route('admin.team') }}">Team</a>
+    </nav>
+
+    <div class="metrics">
+        <div>Orders: {{ $ordersCount }}</div>
+        <div>Schedules: {{ $schedulesCount }}</div>
+        <div>Locations: {{ $locationsCount }}</div>
+        <div>Team Members: {{ $teamCount }}</div>
+    </div>
+</div>

--- a/resources/views/admin/locations.blade.php
+++ b/resources/views/admin/locations.blade.php
@@ -1,0 +1,1 @@
+<div>Admin Locations Placeholder</div>

--- a/resources/views/admin/schedules.blade.php
+++ b/resources/views/admin/schedules.blade.php
@@ -1,0 +1,1 @@
+<div>Admin Schedules Placeholder</div>

--- a/resources/views/admin/team.blade.php
+++ b/resources/views/admin/team.blade.php
@@ -1,0 +1,1 @@
+<div>Admin Team Placeholder</div>

--- a/resources/views/client/dashboard.blade.php
+++ b/resources/views/client/dashboard.blade.php
@@ -1,1 +1,17 @@
-<div>Client Dashboard Placeholder</div>
+<div>
+    <h1>Client Dashboard</h1>
+
+    <nav>
+        <a href="{{ route('client.orders') }}">Orders</a>
+        <a href="{{ route('client.schedules') }}">Schedules</a>
+        <a href="{{ route('client.locations') }}">Locations</a>
+        <a href="{{ route('client.team') }}">Team</a>
+    </nav>
+
+    <div class="metrics">
+        <div>Orders: {{ $ordersCount }}</div>
+        <div>Schedules: {{ $schedulesCount }}</div>
+        <div>Locations: {{ $locationsCount }}</div>
+        <div>Team Members: {{ $teamCount }}</div>
+    </div>
+</div>

--- a/resources/views/client/locations.blade.php
+++ b/resources/views/client/locations.blade.php
@@ -1,0 +1,1 @@
+<div>Client Locations Placeholder</div>

--- a/resources/views/client/schedules.blade.php
+++ b/resources/views/client/schedules.blade.php
@@ -1,0 +1,1 @@
+<div>Client Schedules Placeholder</div>

--- a/resources/views/client/team.blade.php
+++ b/resources/views/client/team.blade.php
@@ -1,0 +1,1 @@
+<div>Client Team Placeholder</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,9 +2,15 @@
 
 use App\Http\Controllers\AuthController;
 use App\Livewire\AdminDashboardLivewireComponent;
+use App\Livewire\AdminLocationsLivewireComponent;
 use App\Livewire\AdminOrdersLivewireComponent;
+use App\Livewire\AdminSchedulesLivewireComponent;
+use App\Livewire\AdminTeamLivewireComponent;
 use App\Livewire\ClientDashboardLivewireComponent;
+use App\Livewire\ClientLocationsLivewireComponent;
 use App\Livewire\ClientOrdersLivewireComponent;
+use App\Livewire\ClientSchedulesLivewireComponent;
+use App\Livewire\ClientTeamLivewireComponent;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -17,9 +23,16 @@ Route::post('/login', [AuthController::class, 'login'])->name('login.post');
 Route::middleware(['auth', 'role:client'])->prefix('client')->name('client.')->group(function () {
     Route::get('dashboard', ClientDashboardLivewireComponent::class)->name('dashboard');
     Route::get('orders', ClientOrdersLivewireComponent::class)->name('orders');
+    Route::get('schedules', ClientSchedulesLivewireComponent::class)->name('schedules');
+    Route::get('locations', ClientLocationsLivewireComponent::class)->name('locations');
+    Route::get('team', ClientTeamLivewireComponent::class)->name('team');
 });
 
 Route::middleware(['auth', 'role:admin'])->prefix('admin')->name('admin.')->group(function () {
     Route::get('dashboard', AdminDashboardLivewireComponent::class)->name('dashboard');
     Route::get('orders', AdminOrdersLivewireComponent::class)->name('orders');
+    Route::get('schedules', AdminSchedulesLivewireComponent::class)->name('schedules');
+    Route::get('locations', AdminLocationsLivewireComponent::class)->name('locations');
+    Route::get('team', AdminTeamLivewireComponent::class)->name('team');
 });
+


### PR DESCRIPTION
## Summary
- show counts of orders, schedules, locations and team on admin and client dashboards
- add simple nav menus linking to Orders, Schedules, Locations and Team pages
- wire new routes and placeholder Livewire components for schedules, locations and team pages

## Testing
- `composer test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: requires GitHub token, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68952b8df9d88329a56d30037ddd36d7