### PR TITLE
Add Sanctum-protected API endpoints for core resources

### DIFF
--- a/app/Http/Controllers/Api/ClientController.php
+++ b/app/Http/Controllers/Api/ClientController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Client;
+use Illuminate\Http\Request;
+
+class ClientController extends Controller
+{
+    public function index()
+    {
+        return Client::all();
+    }
+
+    public function show(Client $client)
+    {
+        return $client;
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+        ]);
+        $client = Client::create($data);
+        return response()->json($client, 201);
+    }
+
+    public function update(Request $request, Client $client)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+        ]);
+        $client->update($data);
+        return $client;
+    }
+
+    public function destroy(Client $client)
+    {
+        $client->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/LocationController.php
+++ b/app/Http/Controllers/Api/LocationController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Location;
+use Illuminate\Http\Request;
+
+class LocationController extends Controller
+{
+    public function index()
+    {
+        return Location::all();
+    }
+
+    public function show(Location $location)
+    {
+        return $location;
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'client_id' => 'required|exists:clients,id',
+            'name' => 'required|string|max:255',
+            'address' => 'required|string',
+        ]);
+        $location = Location::create($data);
+        return response()->json($location, 201);
+    }
+
+    public function update(Request $request, Location $location)
+    {
+        $data = $request->validate([
+            'client_id' => 'sometimes|exists:clients,id',
+            'name' => 'sometimes|string|max:255',
+            'address' => 'sometimes|string',
+        ]);
+        $location->update($data);
+        return $location;
+    }
+
+    public function destroy(Location $location)
+    {
+        $location->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Order;
+use Illuminate\Http\Request;
+
+class OrderController extends Controller
+{
+    public function index()
+    {
+        return Order::with(['client','location','schedule'])->get();
+    }
+
+    public function show(Order $order)
+    {
+        return $order->load(['client','location','schedule']);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'client_id' => 'required|exists:clients,id',
+            'location_id' => 'required|exists:locations,id',
+            'description' => 'required|string',
+            'status' => 'required|string|max:255',
+        ]);
+        $order = Order::create($data);
+        return response()->json($order->load(['client','location','schedule']), 201);
+    }
+
+    public function update(Request $request, Order $order)
+    {
+        $data = $request->validate([
+            'client_id' => 'sometimes|exists:clients,id',
+            'location_id' => 'sometimes|exists:locations,id',
+            'description' => 'sometimes|string',
+            'status' => 'sometimes|string|max:255',
+        ]);
+        $order->update($data);
+        return $order->load(['client','location','schedule']);
+    }
+
+    public function destroy(Order $order)
+    {
+        $order->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/ScheduleController.php
+++ b/app/Http/Controllers/Api/ScheduleController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Schedule;
+use Illuminate\Http\Request;
+
+class ScheduleController extends Controller
+{
+    public function index()
+    {
+        return Schedule::with(['client','order'])->get();
+    }
+
+    public function show(Schedule $schedule)
+    {
+        return $schedule->load(['client','order']);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'client_id' => 'required|exists:clients,id',
+            'order_id' => 'required|exists:orders,id',
+            'scheduled_at' => 'required|date',
+        ]);
+        $schedule = Schedule::create($data);
+        return response()->json($schedule->load(['client','order']), 201);
+    }
+
+    public function update(Request $request, Schedule $schedule)
+    {
+        $data = $request->validate([
+            'client_id' => 'sometimes|exists:clients,id',
+            'order_id' => 'sometimes|exists:orders,id',
+            'scheduled_at' => 'sometimes|date',
+        ]);
+        $schedule->update($data);
+        return $schedule->load(['client','order']);
+    }
+
+    public function destroy(Schedule $schedule)
+    {
+        $schedule->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,12 +6,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasApiTokens;
 
     /**
      * The attributes that are mass assignable.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,32 @@
+# API Endpoints
+
+All endpoints require an `Authorization: Bearer <token>` header containing a valid Laravel Sanctum token.
+
+## Clients
+- `GET /api/clients` – List clients
+- `GET /api/clients/{id}` – Retrieve a client
+- `POST /api/clients` – Create a client
+- `PUT /api/clients/{id}` – Update a client
+- `DELETE /api/clients/{id}` – Delete a client
+
+## Locations
+- `GET /api/locations` – List locations
+- `GET /api/locations/{id}` – Retrieve a location
+- `POST /api/locations` – Create a location
+- `PUT /api/locations/{id}` – Update a location
+- `DELETE /api/locations/{id}` – Delete a location
+
+## Orders
+- `GET /api/orders` – List orders
+- `GET /api/orders/{id}` – Retrieve an order
+- `POST /api/orders` – Create an order
+- `PUT /api/orders/{id}` – Update an order
+- `DELETE /api/orders/{id}` – Delete an order
+
+## Schedules
+- `GET /api/schedules` – List schedules
+- `GET /api/schedules/{id}` – Retrieve a schedule
+- `POST /api/schedules` – Create a schedule
+- `PUT /api/schedules/{id}` – Update a schedule
+- `DELETE /api/schedules/{id}` – Delete a schedule
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\ClientController;
+use App\Http\Controllers\Api\LocationController;
+use App\Http\Controllers\Api\OrderController;
+use App\Http\Controllers\Api\ScheduleController;
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::apiResource('clients', ClientController::class);
+    Route::apiResource('locations', LocationController::class);
+    Route::apiResource('orders', OrderController::class);
+    Route::apiResource('schedules', ScheduleController::class);
+});


### PR DESCRIPTION
## Summary
- add CRUD controllers for clients, locations, orders, and schedules
- expose Sanctum-protected API routes for these resources
- document available endpoints for mobile or third-party use

## Testing
- `composer test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: GitHub 403 requiring token)*

------
https://chatgpt.com/codex/tasks/task_e_68953725707c83299814537ce45fea39