### PR TITLE
Add authentication and Livewire component tests with CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: ["*"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, sqlite, pcntl, dom, curl
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run tests
+        run: php artisan test

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuthenticationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_login_redirects_to_admin_dashboard(): void
+    {
+        $admin = User::factory()->create([
+            'role' => UserRole::Admin,
+            'password' => bcrypt('password'),
+        ]);
+
+        $response = $this->post('/login', [
+            'email' => $admin->email,
+            'password' => 'password',
+        ]);
+
+        $response->assertRedirect(route('admin.dashboard'));
+        $this->assertAuthenticatedAs($admin);
+    }
+
+    public function test_client_login_redirects_to_client_dashboard(): void
+    {
+        $client = User::factory()->create([
+            'role' => UserRole::Client,
+            'password' => bcrypt('password'),
+        ]);
+
+        $response = $this->post('/login', [
+            'email' => $client->email,
+            'password' => 'password',
+        ]);
+
+        $response->assertRedirect(route('client.dashboard'));
+        $this->assertAuthenticatedAs($client);
+    }
+
+    public function test_client_cannot_access_admin_dashboard(): void
+    {
+        $client = User::factory()->create([
+            'role' => UserRole::Client,
+        ]);
+
+        $this->actingAs($client);
+
+        $response = $this->get(route('admin.dashboard'));
+
+        $response->assertForbidden();
+    }
+
+    public function test_admin_cannot_access_client_dashboard(): void
+    {
+        $admin = User::factory()->create([
+            'role' => UserRole::Admin,
+        ]);
+
+        $this->actingAs($admin);
+
+        $response = $this->get(route('client.dashboard'));
+
+        $response->assertForbidden();
+    }
+
+    public function test_guest_is_redirected_to_login_when_accessing_admin_dashboard(): void
+    {
+        $response = $this->get(route('admin.dashboard'));
+
+        $response->assertRedirect(route('login'));
+    }
+}
+

--- a/tests/Feature/Livewire/DashboardComponentTest.php
+++ b/tests/Feature/Livewire/DashboardComponentTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Enums\UserRole;
+use App\Livewire\AdminDashboardLivewireComponent;
+use App\Livewire\ClientDashboardLivewireComponent;
+use App\Models\Client;
+use App\Models\Location;
+use App\Models\Order;
+use App\Models\Schedule;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class DashboardComponentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_dashboard_displays_counts(): void
+    {
+        Notification::fake();
+
+        $admin = User::factory()->create(['role' => UserRole::Admin]);
+        User::factory()->count(2)->create();
+
+        $client = Client::create(['name' => 'Acme']);
+        $location = Location::create([
+            'client_id' => $client->id,
+            'name' => 'HQ',
+            'address' => '123 Street',
+        ]);
+
+        $order = Order::create([
+            'client_id' => $client->id,
+            'location_id' => $location->id,
+            'description' => 'Test',
+            'status' => 'new',
+        ]);
+
+        Schedule::create([
+            'client_id' => $client->id,
+            'order_id' => $order->id,
+            'scheduled_at' => now(),
+        ]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(AdminDashboardLivewireComponent::class)
+            ->assertSet('ordersCount', 1)
+            ->assertSet('schedulesCount', 1)
+            ->assertSet('locationsCount', 1)
+            ->assertSet('teamCount', 3);
+    }
+
+    public function test_client_dashboard_displays_counts_for_authenticated_client(): void
+    {
+        Notification::fake();
+
+        $client = Client::create(['name' => 'Acme']);
+
+        $user = User::factory()->create(['role' => UserRole::Client]);
+        $user->clients()->attach($client->id);
+
+        $otherUser = User::factory()->create();
+        $otherUser->clients()->attach($client->id);
+
+        $location = Location::create([
+            'client_id' => $client->id,
+            'name' => 'HQ',
+            'address' => '123 Street',
+        ]);
+
+        $order = Order::create([
+            'client_id' => $client->id,
+            'location_id' => $location->id,
+            'description' => 'Test',
+            'status' => 'new',
+        ]);
+
+        Schedule::create([
+            'client_id' => $client->id,
+            'order_id' => $order->id,
+            'scheduled_at' => now(),
+        ]);
+
+        $this->actingAs($user);
+
+        Livewire::test(ClientDashboardLivewireComponent::class)
+            ->assertSet('ordersCount', 1)
+            ->assertSet('schedulesCount', 1)
+            ->assertSet('locationsCount', 1)
+            ->assertSet('teamCount', 2);
+    }
+}
+

--- a/tests/Feature/Livewire/OrdersComponentTest.php
+++ b/tests/Feature/Livewire/OrdersComponentTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\AdminOrdersLivewireComponent;
+use App\Livewire\ClientOrdersLivewireComponent;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class OrdersComponentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_orders_component_renders(): void
+    {
+        Livewire::test(AdminOrdersLivewireComponent::class)
+            ->assertSee('Admin Orders Placeholder');
+    }
+
+    public function test_client_orders_component_renders(): void
+    {
+        Livewire::test(ClientOrdersLivewireComponent::class)
+            ->assertSee('Client Orders Placeholder');
+    }
+}
+


### PR DESCRIPTION
## Summary
- add feature tests covering login redirects and route access control
- cover dashboard and order Livewire components with basic rendering assertions
- configure GitHub Actions workflow to run test suite on push

## Testing
- `php artisan test` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895406ef5f88329bcd648e484fe9cea