### PR TITLE
Add Next.js frontend scaffold with Tailwind and shadcn

### DIFF
--- a/frontend/app/admin/analytics/page.tsx
+++ b/frontend/app/admin/analytics/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis, Tooltip } from "recharts";
+
+const data = [
+  { name: "Jan", revenue: 2000 },
+  { name: "Feb", revenue: 2400 },
+  { name: "Mar", revenue: 1800 }
+];
+
+export default function AdminAnalytics() {
+  return (
+    <div className="h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data}>
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip />
+          <Bar dataKey="revenue" fill="#16a34a" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/app/admin/billing/page.tsx
+++ b/frontend/app/admin/billing/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminBilling() {
+  return <div>Billing placeholder</div>;
+}

--- a/frontend/app/admin/clients/page.tsx
+++ b/frontend/app/admin/clients/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminClients() {
+  return <div>Clients placeholder</div>;
+}

--- a/frontend/app/admin/erp/page.tsx
+++ b/frontend/app/admin/erp/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminErp() {
+  return <div>ERP placeholder</div>;
+}

--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -1,0 +1,17 @@
+import { Sidebar, adminNav } from "@/components/Sidebar";
+import { Topbar } from "@/components/Topbar";
+import { AuthGate } from "@/components/AuthGate";
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <AuthGate allow={["admin"]}>
+      <div className="flex">
+        <Sidebar items={adminNav} />
+        <div className="flex flex-1 flex-col">
+          <Topbar />
+          <div className="p-4 space-y-4">{children}</div>
+        </div>
+      </div>
+    </AuthGate>
+  );
+}

--- a/frontend/app/admin/orders/page.tsx
+++ b/frontend/app/admin/orders/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTrigger } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+
+export default function AdminOrders() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="space-y-4">
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <Button>New Order</Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>New Order</DialogHeader>
+          <Input placeholder="Order name" className="mb-2" />
+          <Button onClick={() => setOpen(false)}>Save</Button>
+        </DialogContent>
+      </Dialog>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>ID</TableHead>
+            <TableHead>Client</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>1</TableCell>
+            <TableCell>ACME</TableCell>
+            <TableCell><Badge>Processing</Badge></TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,0 +1,11 @@
+import { OrderCard } from "@/components/OrderCard";
+
+export default function AdminDashboard() {
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      <OrderCard title="Orders in Progress" value="8" />
+      <OrderCard title="Revenue" value="$24k" />
+      <OrderCard title="Clients" value="12" />
+    </div>
+  );
+}

--- a/frontend/app/admin/schedule/page.tsx
+++ b/frontend/app/admin/schedule/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminSchedule() {
+  return <div>Schedule placeholder</div>;
+}

--- a/frontend/app/admin/services/page.tsx
+++ b/frontend/app/admin/services/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminServices() {
+  return <div>Services placeholder</div>;
+}

--- a/frontend/app/admin/settings/page.tsx
+++ b/frontend/app/admin/settings/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { toast } from "@/components/ui/toast";
+
+export default function AdminSettings() {
+  return (
+    <div className="space-y-2">
+      <Input placeholder="Setting" />
+      <Button onClick={() => toast("Settings saved")}>Save</Button>
+    </div>
+  );
+}

--- a/frontend/app/admin/staff/page.tsx
+++ b/frontend/app/admin/staff/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminStaff() {
+  return <div>Staff placeholder</div>;
+}

--- a/frontend/app/client/analytics/page.tsx
+++ b/frontend/app/client/analytics/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { Line, LineChart, ResponsiveContainer, XAxis, YAxis, Tooltip } from "recharts";
+
+const data = [
+  { name: "Jan", orders: 30 },
+  { name: "Feb", orders: 45 },
+  { name: "Mar", orders: 28 }
+];
+
+export default function ClientAnalytics() {
+  return (
+    <div className="h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data}>
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="orders" stroke="#2563eb" />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/app/client/layout.tsx
+++ b/frontend/app/client/layout.tsx
@@ -1,0 +1,17 @@
+import { Sidebar, clientNav } from "@/components/Sidebar";
+import { Topbar } from "@/components/Topbar";
+import { AuthGate } from "@/components/AuthGate";
+
+export default function ClientLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <AuthGate allow={["client"]}>
+      <div className="flex">
+        <Sidebar items={clientNav} />
+        <div className="flex flex-1 flex-col">
+          <Topbar />
+          <div className="p-4 space-y-4">{children}</div>
+        </div>
+      </div>
+    </AuthGate>
+  );
+}

--- a/frontend/app/client/locations/page.tsx
+++ b/frontend/app/client/locations/page.tsx
@@ -1,0 +1,3 @@
+export default function ClientLocations() {
+  return <div>Locations placeholder</div>;
+}

--- a/frontend/app/client/orders/page.tsx
+++ b/frontend/app/client/orders/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTrigger } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+
+export default function OrdersPage() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="space-y-4">
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <Button>New Order</Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>New Order</DialogHeader>
+          <Input placeholder="Order name" className="mb-2" />
+          <Button onClick={() => setOpen(false)}>Save</Button>
+        </DialogContent>
+      </Dialog>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>ID</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>1</TableCell>
+            <TableCell><Badge>Pending</Badge></TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/app/client/page.tsx
+++ b/frontend/app/client/page.tsx
@@ -1,0 +1,21 @@
+import { OrderCard } from "@/components/OrderCard";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+export default function ClientDashboard() {
+  return (
+    <Tabs defaultValue="overview" className="space-y-4">
+      <TabsList>
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+        <TabsTrigger value="details">Details</TabsTrigger>
+      </TabsList>
+      <TabsContent value="overview" className="grid gap-4 md:grid-cols-3">
+        <OrderCard title="Active Orders" value="5" />
+        <OrderCard title="Next Pickup" value="Tomorrow" />
+        <OrderCard title="Monthly Spend" value="$1200" />
+      </TabsContent>
+      <TabsContent value="details">
+        <p className="text-sm text-gray-500">More details coming soon.</p>
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/frontend/app/client/schedule/page.tsx
+++ b/frontend/app/client/schedule/page.tsx
@@ -1,0 +1,3 @@
+export default function ClientSchedule() {
+  return <div>Schedule placeholder</div>;
+}

--- a/frontend/app/client/settings/page.tsx
+++ b/frontend/app/client/settings/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { toast } from "@/components/ui/toast";
+
+export default function ClientSettings() {
+  return (
+    <div className="space-y-2">
+      <Input placeholder="Company Name" />
+      <Button onClick={() => toast("Settings saved")}>Save</Button>
+    </div>
+  );
+}

--- a/frontend/app/client/team/page.tsx
+++ b/frontend/app/client/team/page.tsx
@@ -1,0 +1,3 @@
+export default function ClientTeam() {
+  return <div>Team placeholder</div>;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,22 @@
+import "../styles/globals.css";
+import type { Metadata } from "next";
+import { ThemeProvider } from "@/components/ThemeProvider";
+import { Toaster } from "@/components/ui/toast";
+
+export const metadata: Metadata = {
+  title: "Clean Basket Portal",
+  description: "B2B portal"
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <ThemeProvider>
+          {children}
+          <Toaster position="top-right" />
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
+import { useRouter } from "next/navigation";
+
+export default function Home() {
+  const { login } = useAuth();
+  const router = useRouter();
+
+  const handle = (role: "client" | "admin") => {
+    login(role);
+    router.push("/" + role);
+  };
+
+  return (
+    <main className="flex h-screen items-center justify-center space-x-4">
+      <Button onClick={() => handle("client")}>Client Login</Button>
+      <Button onClick={() => handle("admin")}>Admin Login</Button>
+    </main>
+  );
+}

--- a/frontend/components/AuthGate.tsx
+++ b/frontend/components/AuthGate.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Role, useAuth } from "@/hooks/useAuth";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
+
+export function AuthGate({ children, allow }: { children: React.ReactNode; allow: Role[] }) {
+  const { role } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (role && !allow.includes(role)) {
+      router.replace("/" + role);
+    }
+  }, [role, allow, router]);
+
+  if (!role) {
+    return <LoadingSpinner />;
+  }
+
+  if (!allow.includes(role)) {
+    return <div className="p-4">Unauthorized</div>;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/components/LoadingSpinner.tsx
+++ b/frontend/components/LoadingSpinner.tsx
@@ -1,0 +1,7 @@
+export function LoadingSpinner() {
+  return (
+    <div className="flex items-center justify-center p-4">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-transparent"></div>
+    </div>
+  );
+}

--- a/frontend/components/OrderCard.tsx
+++ b/frontend/components/OrderCard.tsx
@@ -1,0 +1,22 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+interface OrderCardProps {
+  title: string;
+  value: string;
+  status?: string;
+}
+
+export function OrderCard({ title, value, status }: OrderCardProps) {
+  return (
+    <Card>
+      <CardHeader className="flex justify-between">
+        <span>{title}</span>
+        {status && <Badge>{status}</Badge>}
+      </CardHeader>
+      <CardContent>
+        <p className="text-2xl font-bold">{value}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -1,0 +1,55 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Home, BarChart2, ShoppingCart, Settings, Users, Calendar, MapPin, CreditCard } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface Item {
+  href: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+export function Sidebar({ items }: { items: Item[] }) {
+  const pathname = usePathname();
+  return (
+    <aside className="w-60 bg-gray-100 dark:bg-gray-900 h-screen p-4 space-y-2">
+      {items.map((item) => (
+        <Link
+          key={item.href}
+          href={item.href}
+          className={cn(
+            "flex items-center space-x-2 rounded-md p-2 text-sm font-medium hover:bg-gray-200 dark:hover:bg-gray-800",
+            pathname === item.href && "bg-gray-200 dark:bg-gray-800"
+          )}
+        >
+          <item.icon className="w-4 h-4" />
+          <span>{item.label}</span>
+        </Link>
+      ))}
+    </aside>
+  );
+}
+
+export const clientNav: Item[] = [
+  { href: "/client", label: "Dashboard", icon: Home },
+  { href: "/client/orders", label: "Orders", icon: ShoppingCart },
+  { href: "/client/analytics", label: "Analytics", icon: BarChart2 },
+  { href: "/client/schedule", label: "Schedule", icon: Calendar },
+  { href: "/client/locations", label: "Locations", icon: MapPin },
+  { href: "/client/team", label: "Team", icon: Users },
+  { href: "/client/settings", label: "Settings", icon: Settings }
+];
+
+export const adminNav: Item[] = [
+  { href: "/admin", label: "Dashboard", icon: Home },
+  { href: "/admin/clients", label: "Clients", icon: Users },
+  { href: "/admin/services", label: "Services", icon: ShoppingCart },
+  { href: "/admin/orders", label: "Orders", icon: ShoppingCart },
+  { href: "/admin/staff", label: "Staff", icon: Users },
+  { href: "/admin/schedule", label: "Schedule", icon: Calendar },
+  { href: "/admin/analytics", label: "Analytics", icon: BarChart2 },
+  { href: "/admin/billing", label: "Billing", icon: CreditCard },
+  { href: "/admin/erp", label: "ERP", icon: Settings },
+  { href: "/admin/settings", label: "Settings", icon: Settings }
+];

--- a/frontend/components/ThemeProvider.tsx
+++ b/frontend/components/ThemeProvider.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { ReactNode } from "react";
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="light" enableSystem>
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/frontend/components/Topbar.tsx
+++ b/frontend/components/Topbar.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { useAuth } from "@/hooks/useAuth";
+
+export function Topbar() {
+  const { logout } = useAuth();
+  return (
+    <header className="flex items-center justify-between px-4 py-2 border-b bg-white dark:bg-gray-950">
+      <span className="font-bold">Clean Basket</span>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline">Menu</Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={logout}>Logout</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </header>
+  );
+}

--- a/frontend/components/ui/badge.tsx
+++ b/frontend/components/ui/badge.tsx
@@ -1,0 +1,5 @@
+import { cn } from "@/lib/utils";
+
+export function Badge({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) {
+  return <span className={cn("inline-flex items-center rounded bg-blue-100 px-2 py-1 text-xs font-medium", className)} {...props} />;
+}

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-blue-600 text-white hover:bg-blue-700",
+        outline: "border border-gray-300 hover:bg-gray-100 dark:border-gray-700",
+      },
+      size: {
+        default: "h-9 px-4",
+        sm: "h-8 px-3",
+        lg: "h-10 px-8",
+      }
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default"
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-lg border bg-white dark:bg-gray-950 shadow", className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-4 border-b", className)} {...props} />
+  )
+);
+CardHeader.displayName = "CardHeader";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-4", className)} {...props} />
+  )
+);
+CardContent.displayName = "CardContent";
+
+export { Card, CardHeader, CardContent };

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -1,0 +1,28 @@
+"use client";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogContent = ({ className, ...props }: DialogPrimitive.DialogContentProps) => (
+  <DialogPrimitive.Portal>
+    <DialogPrimitive.Overlay className="fixed inset-0 bg-black/50" />
+    <DialogPrimitive.Content
+      className={cn("fixed top-1/2 left-1/2 w-96 -translate-x-1/2 -translate-y-1/2 rounded bg-white p-6 shadow", className)}
+      {...props}
+    />
+  </DialogPrimitive.Portal>
+);
+const DialogHeader = ({ children }: { children: React.ReactNode }) => (
+  <div className="mb-4 flex items-center justify-between">
+    {children}
+    <DialogPrimitive.Close asChild>
+      <button className="rounded p-1 hover:bg-gray-100">
+        <X className="h-4 w-4" />
+      </button>
+    </DialogPrimitive.Close>
+  </div>
+);
+
+export { Dialog, DialogTrigger, DialogContent, DialogHeader };

--- a/frontend/components/ui/dropdown-menu.tsx
+++ b/frontend/components/ui/dropdown-menu.tsx
@@ -1,0 +1,16 @@
+"use client";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenuContent = ({ className, ...props }: DropdownMenuPrimitive.DropdownMenuContentProps) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content className={cn("z-50 min-w-[8rem] overflow-hidden rounded-md border bg-white p-1 shadow-md", className)} {...props} />
+  </DropdownMenuPrimitive.Portal>
+);
+const DropdownMenuItem = ({ className, ...props }: DropdownMenuPrimitive.DropdownMenuItemProps) => (
+  <DropdownMenuPrimitive.Item className={cn("flex cursor-pointer select-none items-center rounded-sm px-2 py-1 text-sm hover:bg-gray-100", className)} {...props} />
+);
+
+export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem };

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => {
+    return <input ref={ref} className={cn("flex h-9 w-full rounded-md border px-3 py-1 text-sm", className)} {...props} />;
+  }
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/frontend/components/ui/table.tsx
+++ b/frontend/components/ui/table.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <table ref={ref} className={cn("w-full text-sm", className)} {...props} />
+  )
+);
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <thead ref={ref} className={cn("bg-gray-100", className)} {...props} />
+  )
+);
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => <tbody ref={ref} className={cn("divide-y", className)} {...props} />
+);
+TableBody.displayName = "TableBody";
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => <tr ref={ref} className={cn("hover:bg-gray-50", className)} {...props} />
+);
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th ref={ref} className={cn("px-2 py-1 text-left font-medium", className)} {...props} />
+  )
+);
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <td ref={ref} className={cn("px-2 py-1", className)} {...props} />
+  )
+);
+TableCell.displayName = "TableCell";
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell };

--- a/frontend/components/ui/tabs.tsx
+++ b/frontend/components/ui/tabs.tsx
@@ -1,0 +1,14 @@
+"use client";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { cn } from "@/lib/utils";
+
+const Tabs = TabsPrimitive.Root;
+const TabsList = ({ className, ...props }: TabsPrimitive.TabsListProps) => (
+  <TabsPrimitive.List className={cn("flex border-b", className)} {...props} />
+);
+const TabsTrigger = ({ className, ...props }: TabsPrimitive.TabsTriggerProps) => (
+  <TabsPrimitive.Trigger className={cn("px-4 py-2 text-sm data-[state=active]:border-b-2", className)} {...props} />
+);
+const TabsContent = TabsPrimitive.Content;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/frontend/components/ui/toast.tsx
+++ b/frontend/components/ui/toast.tsx
@@ -1,0 +1,4 @@
+"use client";
+import { Toaster, toast } from "sonner";
+
+export { Toaster, toast };

--- a/frontend/hooks/useApi.ts
+++ b/frontend/hooks/useApi.ts
@@ -1,0 +1,6 @@
+import { useMemo } from "react";
+import { api } from "@/lib/api";
+
+export function useApi() {
+  return useMemo(() => api, []);
+}

--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -1,0 +1,26 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export type Role = "admin" | "client" | null;
+
+export function useAuth() {
+  const [role, setRole] = useState<Role>(null);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("role") as Role;
+    setRole(stored);
+  }, []);
+
+  const login = (r: Role) => {
+    if (!r) return;
+    window.localStorage.setItem("role", r);
+    setRole(r);
+  };
+
+  const logout = () => {
+    window.localStorage.removeItem("role");
+    setRole(null);
+  };
+
+  return { role, login, logout };
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,6 @@
+import axios from "axios";
+
+export const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000/api",
+  withCredentials: true
+});

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "clean-basket-b2b-portal",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-dropdown-menu": "^1.0.6",
+    "@radix-ui/react-tabs": "^1.0.5",
+    "@radix-ui/react-toast": "^1.0.5",
+    "axios": "^1.6.7",
+    "class-variance-authority": "^0.7.0",
+    "lucide-react": "^0.292.0",
+    "next": "14.1.0",
+    "next-themes": "^0.2.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "recharts": "^2.10.0",
+    "sonner": "^1.4.41",
+    "clsx": "^1.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.4.2",
+    "@types/react": "18.2.15",
+    "@types/react-dom": "18.2.7",
+    "autoprefixer": "^10.4.15",
+    "eslint": "^8.45.0",
+    "eslint-config-next": "14.1.0",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.3",
+    "typescript": "5.1.6"
+  }
+}

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,0 +1,6 @@
+import tailwindcss from "tailwindcss";
+import autoprefixer from "autoprefixer";
+
+export default {
+  plugins: [tailwindcss, autoprefixer]
+};

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, :root {
+  height: 100%;
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./pages/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}"
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 app in `frontend`
- add Tailwind CSS, shadcn/ui components, lucide icons and theme provider
- include client and admin dashboards with placeholder analytics charts and mock auth gate

## Testing
- `pnpm install` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm lint` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_689734b8274083298645d11d2456275f